### PR TITLE
Check access permissions before calling Gatt service

### DIFF
--- a/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableGattDeviceService.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableGattDeviceService.cs
@@ -207,6 +207,19 @@ namespace BluetoothLEExplorer.Models
 
             try
             {
+                // Request the necessary access permissions for the service and abort
+                // if permissions are denied.
+                GattOpenStatus status = await Service.OpenAsync(GattSharingMode.SharedReadAndWrite);
+                if (status != GattOpenStatus.Success && status != GattOpenStatus.AlreadyOpened)
+                {
+                    string error = " - Error: " + status.ToString();
+                    Name += error;
+                    sb.Append(error);
+                    Debug.WriteLine(sb.ToString());
+
+                    return;
+                }
+
                 CancellationTokenSource tokenSource = new CancellationTokenSource(5000);
                 var t = Task.Run(() => Service.GetCharacteristicsAsync(Windows.Devices.Bluetooth.BluetoothCacheMode.Uncached), tokenSource.Token);
 
@@ -246,11 +259,6 @@ namespace BluetoothLEExplorer.Models
                         return;
                     }
                 }
-            }
-            catch (UnauthorizedAccessException)
-            {
-                // Bug 9145823:GetCharacteristicsAsync throw System.UnauthorizedAccessException when querying GenericAccess Service Characteristics
-                Name += " - Unauthorized Access";
             }
             catch (Exception ex)
             {

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Package.appxmanifest
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
-  <Identity Name="Microsoft.BluetoothLEExplorer" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="1.11.1.0" />
+  <Identity Name="Microsoft.BluetoothLEExplorer" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="1.11.2.0" />
   <mp:PhoneIdentity PhoneProductId="8fce680c-fda2-4d28-8e68-9bb7d53f192f" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Bluetooth LE Explorer</DisplayName>


### PR DESCRIPTION
Bluetooth LE Explorer was crashing while trying to access a service from a keyboard because we can’t access the HID service. Add a permission check and gracefully exit if it fails. 

HOW BUILT: Using Visual Studio it built successfully for x86, x64, and ARM

HOW TESTED: Verified the app using a Bluetooth LE keyboard which previously was causing a crash due to invalid permissions. Now the keyboard correctly displays an access denied error instead of crashing.