### PR TITLE
Fix UTF16 parsing crash and string typo

### DIFF
--- a/BluetoothLEExplorer/BluetoothLEExplorer/Models/GattSampleContext.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Models/GattSampleContext.cs
@@ -232,7 +232,7 @@ namespace BluetoothLEExplorer.Models
 
             if(adapter ==  null)
             {
-                MessageDialog msg = new MessageDialog("Error getting access to Bluetooth adaptor. Do you have a have bluetooth enabled?", "Error");
+                MessageDialog msg = new MessageDialog("Error getting access to Bluetooth adapter. Do you have a have bluetooth enabled?", "Error");
                 await msg.ShowAsync();
 
                 IsPeripheralRoleSupported = false;

--- a/BluetoothLEExplorer/GattHelper/Converters/GattConvert.cs
+++ b/BluetoothLEExplorer/GattHelper/Converters/GattConvert.cs
@@ -136,7 +136,10 @@ namespace GattHelper.Converters
             DataReader reader = DataReader.FromBuffer(buffer);
             reader.UnicodeEncoding = Windows.Storage.Streams.UnicodeEncoding.Utf16LE;
             reader.ByteOrder = Windows.Storage.Streams.ByteOrder.LittleEndian;
-            return reader.ReadString(buffer.Length);
+
+            // UTF16 characters are 2 bytes long and ReadString takes the character count,
+            // divide the buffer length by 2.
+            return reader.ReadString(buffer.Length / 2);
         }
 
         public static Int16 ToInt16(IBuffer buffer)


### PR DESCRIPTION
UTF16 parsing was incorrectly passing in the number of bytes instead of the number of characters causing a buffer overflow. 