### PR TITLE
Fixed minor issues preventing build/debug

### DIFF
--- a/BluetoothLEExplorer/BluetoothLEExplorer.sln
+++ b/BluetoothLEExplorer/BluetoothLEExplorer.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.16
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30309.148
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GattServicesLibrary", "..\GattServicesLibrary\GattServicesLibrary\GattServicesLibrary.csproj", "{644F40AD-EABB-4570-B9B7-E3F8DDAA80F3}"
 EndProject
@@ -76,6 +76,8 @@ Global
 		{BE79FC52-6041-4913-B0D4-66C100944904}.Release|x86.ActiveCfg = Release|x86
 		{BE79FC52-6041-4913-B0D4-66C100944904}.Release|x86.Build.0 = Release|x86
 		{AD1CBE3C-A68A-4E02-8001-E02B815560EE}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{AD1CBE3C-A68A-4E02-8001-E02B815560EE}.Debug|Any CPU.Build.0 = Debug|x86
+		{AD1CBE3C-A68A-4E02-8001-E02B815560EE}.Debug|Any CPU.Deploy.0 = Debug|x86
 		{AD1CBE3C-A68A-4E02-8001-E02B815560EE}.Debug|ARM.ActiveCfg = Debug|ARM
 		{AD1CBE3C-A68A-4E02-8001-E02B815560EE}.Debug|ARM.Build.0 = Debug|ARM
 		{AD1CBE3C-A68A-4E02-8001-E02B815560EE}.Debug|ARM.Deploy.0 = Debug|ARM
@@ -96,6 +98,7 @@ Global
 		{AD1CBE3C-A68A-4E02-8001-E02B815560EE}.Release|x86.Build.0 = Release|x86
 		{AD1CBE3C-A68A-4E02-8001-E02B815560EE}.Release|x86.Deploy.0 = Release|x86
 		{6F503DF9-71C9-4340-90BB-D9AA14ADB686}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{6F503DF9-71C9-4340-90BB-D9AA14ADB686}.Debug|Any CPU.Build.0 = Debug|x86
 		{6F503DF9-71C9-4340-90BB-D9AA14ADB686}.Debug|ARM.ActiveCfg = Debug|ARM
 		{6F503DF9-71C9-4340-90BB-D9AA14ADB686}.Debug|ARM.Build.0 = Debug|ARM
 		{6F503DF9-71C9-4340-90BB-D9AA14ADB686}.Debug|ARM.Deploy.0 = Debug|ARM
@@ -121,5 +124,8 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{BE79FC52-6041-4913-B0D4-66C100944904} = {92EE95F6-40B6-4E5A-97C9-E4234D17C022}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A45C5589-2429-4B75-8283-6756C5DD2991}
 	EndGlobalSection
 EndGlobal

--- a/BluetoothLEExplorer/BluetoothLEExplorer/BluetoothLEExplorer.csproj
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/BluetoothLEExplorer.csproj
@@ -99,7 +99,7 @@
   <PropertyGroup>
     <PackageCertificateKeyFile>
     </PackageCertificateKeyFile>
-    <AppxPackageSigningEnabled>true</AppxPackageSigningEnabled>
+    <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
     <AppxAutoIncrementPackageRevision>True</AppxAutoIncrementPackageRevision>
     <AppxSymbolPackageEnabled>True</AppxSymbolPackageEnabled>
   </PropertyGroup>


### PR DESCRIPTION
This project had two minor issues that prevented it from building/debugging:

- [Project not selected to build for this solution configuration](https://stackoverflow.com/questions/37675012/project-not-selected-to-build-for-this-solution-configuration).  I fixed this by enabling the build and deploy options for two projects in the solution.
- [No certificate found with the supplied thumbprint](https://stackoverflow.com/questions/57578299/uwp-no-certificate-found-with-the-supplied-thumbprint).  I fixed this by [disabling Appx Package Signing](https://stackoverflow.com/questions/46992907/how-do-i-skip-the-packaging-step-when-building-a-windows-store-app-using-msbuild).

I also updated the project to work with the most recent version of Visual Studio.