### PR TITLE
Changed version number while updating app store

### DIFF
--- a/BluetoothLEExplorer/BluetoothLEExplorer/Package.appxmanifest
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" IgnorableNamespaces="uap mp uap3">
-  <Identity Name="Microsoft.BluetoothLEExplorer" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="1.11.7.0" />
+  <Identity Name="Microsoft.BluetoothLEExplorer" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="1.13.0.0" />
   <mp:PhoneIdentity PhoneProductId="8fce680c-fda2-4d28-8e68-9bb7d53f192f" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Bluetooth LE Explorer</DisplayName>


### PR DESCRIPTION
I updated the Microsoft store app and the version number I gave them was 1.13.0 so I'm keeping that version number in sync with here.