### PR TITLE
Fix bugs

### DIFF
--- a/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableBluetoothLEDevice.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableBluetoothLEDevice.cs
@@ -18,6 +18,7 @@ using Windows.UI.Xaml.Media.Imaging;
 using Windows.Foundation.Metadata;
 using System.Collections;
 using System.Collections.Generic;
+using BluetoothLEExplorer.Services.GattUuidHelpers;
 
 namespace BluetoothLEExplorer.Models
 {
@@ -218,6 +219,8 @@ namespace BluetoothLEExplorer.Models
             }
         }
 
+        public bool CanPair(bool isPaired, bool isConnectable) { return !isPaired && isConnectable; }
+
         private bool isSecureConnection;
 
         public bool IsSecureConnection
@@ -365,31 +368,6 @@ namespace BluetoothLEExplorer.Models
                 {
                     rssi = newValue;
                     OnPropertyChanged(new PropertyChangedEventArgs("RSSI"));
-                }
-            }
-        }
-
-        /// <summary>
-        /// Source for <see cref="BatteryLevel"/>
-        /// </summary>
-        private int batteryLevel = -1;
-
-        /// <summary>
-        /// Gets or sets the Battery level of this device. -1 if unknown.
-        /// </summary>
-        public int BatteryLevel
-        {
-            get
-            {
-                return batteryLevel;
-            }
-
-            set
-            {
-                if (batteryLevel != value)
-                {
-                    batteryLevel = value;
-                    OnPropertyChanged(new PropertyChangedEventArgs("BatteryLevel"));
                 }
             }
         }
@@ -553,7 +531,10 @@ namespace BluetoothLEExplorer.Models
                             System.Diagnostics.Debug.WriteLine(debugMsg + "GetGattServiceAsync SUCCESS");
                             foreach (var serv in result.Services)
                             {
-                                Services.Add(new ObservableGattDeviceService(serv));
+                                if (!GattServiceUuidHelper.IsReserved(serv.Uuid))
+                                {
+                                    Services.Add(new ObservableGattDeviceService(serv));
+                                }
                             }
 
                             ServiceCount = Services.Count();

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableBluetoothLEDevice.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableBluetoothLEDevice.cs
@@ -219,7 +219,7 @@ namespace BluetoothLEExplorer.Models
             }
         }
 
-        public bool CanPair(bool isPaired) { return !isPaired; }
+        public bool CanPair(bool isPaired, bool IsConnectable) { return !isPaired && IsConnectable; }
 
         private bool isSecureConnection;
 

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableBluetoothLEDevice.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableBluetoothLEDevice.cs
@@ -219,7 +219,7 @@ namespace BluetoothLEExplorer.Models
             }
         }
 
-        public bool CanPair(bool isPaired, bool isConnectable) { return !isPaired && isConnectable; }
+        public bool CanPair(bool isPaired) { return !isPaired; }
 
         private bool isSecureConnection;
 

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableGattDeviceService.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableGattDeviceService.cs
@@ -210,7 +210,16 @@ namespace BluetoothLEExplorer.Models
             {
                 // Request the necessary access permissions for the service and abort
                 // if permissions are denied.
-                GattOpenStatus status = await Service.OpenAsync(GattSharingMode.SharedReadAndWrite);
+                GattOpenStatus status;
+                if (GattServiceUuidHelper.IsReadOnly(service.Uuid))
+                {
+                    status = await Service.OpenAsync(GattSharingMode.SharedReadOnly);
+                }
+                else
+                {
+                    status = await Service.OpenAsync(GattSharingMode.SharedReadAndWrite);
+                }
+
                 if (status != GattOpenStatus.Success && status != GattOpenStatus.AlreadyOpened)
                 {
                     string error = " - Error: " + status.ToString();

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableGattDeviceService.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableGattDeviceService.cs
@@ -168,15 +168,6 @@ namespace BluetoothLEExplorer.Models
         }
 
         /// <summary>
-        /// Destruct by clearing characteristic list
-        /// </summary>
-        ~ObservableGattDeviceService()
-        {
-            // ToDo: Figure out why this causes app to crash when refresh button is mashed
-            // Characteristics.Clear();
-        }
-
-        /// <summary>
         /// Adds the SelectedCharacteristic_PropertyChanged event handler
         /// </summary>
         private void SelectedCharacteristic_PropertyChanged()
@@ -211,15 +202,7 @@ namespace BluetoothLEExplorer.Models
             {
                 // Request the necessary access permissions for the service and abort
                 // if permissions are denied.
-                GattOpenStatus status;
-                if (GattServiceUuidHelper.IsReadOnly(service.Uuid))
-                {
-                    status = await Service.OpenAsync(GattSharingMode.SharedReadOnly);
-                }
-                else
-                {
-                    status = await Service.OpenAsync(GattSharingMode.SharedReadAndWrite);
-                }
+                GattOpenStatus status = await Service.OpenAsync(GattSharingMode.SharedReadAndWrite);
 
                 if (status != GattOpenStatus.Success && status != GattOpenStatus.AlreadyOpened)
                 {

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableGattDeviceService.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableGattDeviceService.cs
@@ -172,7 +172,8 @@ namespace BluetoothLEExplorer.Models
         /// </summary>
         ~ObservableGattDeviceService()
         {
-            Characteristics.Clear();
+            // ToDo: Figure out why this causes app to crash when refresh button is mashed
+            // Characteristics.Clear();
         }
 
         /// <summary>

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Package.appxmanifest
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" IgnorableNamespaces="uap mp uap3">
-  <Identity Name="Microsoft.BluetoothLEExplorer" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="1.13.1.0" />
+  <Identity Name="Microsoft.BluetoothLEExplorer" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="1.13.2.0" />
   <mp:PhoneIdentity PhoneProductId="8fce680c-fda2-4d28-8e68-9bb7d53f192f" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Bluetooth LE Explorer</DisplayName>

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Package.appxmanifest
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" IgnorableNamespaces="uap mp uap3">
-  <Identity Name="Microsoft.BluetoothLEExplorer" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="1.13.0.0" />
+  <Identity Name="Microsoft.BluetoothLEExplorer" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="1.13.1.0" />
   <mp:PhoneIdentity PhoneProductId="8fce680c-fda2-4d28-8e68-9bb7d53f192f" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Bluetooth LE Explorer</DisplayName>

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Services/GattUuidsService/GattUuidsService.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Services/GattUuidsService/GattUuidsService.cs
@@ -4,6 +4,7 @@
 //----------------------------------------------------------------------------------------------
 using System;
 using Windows.Devices.Bluetooth;
+using Windows.Devices.Bluetooth.GenericAttributeProfile;
 
 namespace BluetoothLEExplorer.Services.GattUuidHelpers
 {
@@ -23,6 +24,21 @@ namespace BluetoothLEExplorer.Services.GattUuidHelpers
                 return name.ToString();
             }
             return uuid.ToString();
+        }
+
+        public static bool IsReadOnly(Guid uuid)
+        {
+            if (GattServiceUuids.DeviceInformation == uuid) return true;
+            if (GattServiceUuids.GenericAttribute == uuid) return true;
+            if (GattServiceUuids.GenericAccess == uuid) return true;
+            if (GattServiceUuids.ScanParameters == uuid) return true;
+            return false;
+        }
+
+        public static bool IsReserved(Guid uuid)
+        {
+            if (GattServiceUuids.HumanInterfaceDevice == uuid) return true;
+            return false;
         }
     }
 

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Services/GattUuidsService/GattUuidsService.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Services/GattUuidsService/GattUuidsService.cs
@@ -28,16 +28,21 @@ namespace BluetoothLEExplorer.Services.GattUuidHelpers
 
         public static bool IsReadOnly(Guid uuid)
         {
-            if (GattServiceUuids.DeviceInformation == uuid) return true;
-            if (GattServiceUuids.GenericAttribute == uuid) return true;
-            if (GattServiceUuids.GenericAccess == uuid) return true;
-            if (GattServiceUuids.ScanParameters == uuid) return true;
+            if (GattServiceUuids.DeviceInformation == uuid || GattServiceUuids.GenericAttribute == uuid || GattServiceUuids.GenericAccess == uuid || GattServiceUuids.ScanParameters == uuid)
+            {
+                return true;
+            }
+
             return false;
         }
 
         public static bool IsReserved(Guid uuid)
         {
-            if (GattServiceUuids.HumanInterfaceDevice == uuid) return true;
+            if (GattServiceUuids.HumanInterfaceDevice == uuid)
+            {
+                return true;
+            }
+            
             return false;
         }
     }

--- a/BluetoothLEExplorer/BluetoothLEExplorer/ViewModels/CharacteristicPageViewModel.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/ViewModels/CharacteristicPageViewModel.cs
@@ -16,6 +16,7 @@ using Windows.Storage.Streams;
 using Windows.UI.Xaml.Navigation;
 using Windows.UI.Popups;
 using GattHelper.Converters;
+using BluetoothLEExplorer.Services.GattUuidHelpers;
 
 namespace BluetoothLEExplorer.ViewModels
 {
@@ -297,6 +298,11 @@ namespace BluetoothLEExplorer.ViewModels
         {
             get
             {
+                if (GattServiceUuidHelper.IsReadOnly(Characteristic.Characteristic.Service.Uuid))
+                {
+                    return false;
+                }
+
                 return ( Characteristic.Characteristic.CharacteristicProperties.HasFlag(GattCharacteristicProperties.Write) ||
                          Characteristic.Characteristic.CharacteristicProperties.HasFlag(GattCharacteristicProperties.WriteWithoutResponse));
             }
@@ -683,6 +689,12 @@ namespace BluetoothLEExplorer.ViewModels
                 foreach (GattCharacteristicProperties p in Enum.GetValues(typeof(GattCharacteristicProperties)))
                 {
                     if (p == GattCharacteristicProperties.None)
+                    {
+                        continue;
+                    }
+
+                    if (BluetoothLEExplorer.Services.GattUuidHelpers.GattServiceUuidHelper.IsReadOnly(Characteristic.Characteristic.Service.Uuid) &&
+                        (p == GattCharacteristicProperties.Write || p == GattCharacteristicProperties.WriteWithoutResponse))
                     {
                         continue;
                     }

--- a/BluetoothLEExplorer/BluetoothLEExplorer/ViewModels/CharacteristicPageViewModel.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/ViewModels/CharacteristicPageViewModel.cs
@@ -298,6 +298,7 @@ namespace BluetoothLEExplorer.ViewModels
         {
             get
             {
+                // Windows blocks writing on certain characteristics
                 if (GattServiceUuidHelper.IsReadOnly(Characteristic.Characteristic.Service.Uuid))
                 {
                     return false;

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Views/Discover.xaml
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Views/Discover.xaml
@@ -208,9 +208,6 @@
                                     <TextBlock Margin="5,0,0,0">
                                     RSSI: <Run Text="{x:Bind RSSI, Mode=OneWay}" />
                                     </TextBlock>
-                                    <TextBlock Margin="5,0,0,0" Visibility="{x:Bind BatteryLevel, Mode=OneWay, Converter={StaticResource CollapsedWhenNegOne}}">
-                                    Battery: <Run Text="{x:Bind BatteryLevel, Mode=OneWay}" />
-                                    </TextBlock>
                                 </StackPanel>
                             </Grid>
                             <StackPanel Grid.Row="1" Grid.ColumnSpan="2">
@@ -237,7 +234,7 @@
                                 </TextBlock>
                             </StackPanel>
                             <StackPanel Grid.Row="2" Grid.ColumnSpan="2">
-                                <Button Name="Pair" Click="{x:Bind DoInAppPairing}" HorizontalAlignment="Center">
+                                <Button Name="Pair" Click="{x:Bind DoInAppPairing}" HorizontalAlignment="Center" IsEnabled="{x:Bind CanPair(IsPaired, IsConnectable), Mode=OneWay}">
                                     Pair
                                 </Button>
                             </StackPanel>

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Views/Discover.xaml
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Views/Discover.xaml
@@ -234,7 +234,7 @@
                                 </TextBlock>
                             </StackPanel>
                             <StackPanel Grid.Row="2" Grid.ColumnSpan="2">
-                                <Button Name="Pair" Click="{x:Bind DoInAppPairing}" HorizontalAlignment="Center" IsEnabled="{x:Bind CanPair(IsPaired, IsConnectable), Mode=OneWay}">
+                                <Button Name="Pair" Click="{x:Bind DoInAppPairing}" HorizontalAlignment="Center" IsEnabled="{x:Bind CanPair(IsPaired), Mode=OneWay}">
                                     Pair
                                 </Button>
                             </StackPanel>

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Views/Discover.xaml
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Views/Discover.xaml
@@ -234,7 +234,7 @@
                                 </TextBlock>
                             </StackPanel>
                             <StackPanel Grid.Row="2" Grid.ColumnSpan="2">
-                                <Button Name="Pair" Click="{x:Bind DoInAppPairing}" HorizontalAlignment="Center" IsEnabled="{x:Bind CanPair(IsPaired), Mode=OneWay}">
+                                <Button Name="Pair" Click="{x:Bind DoInAppPairing}" HorizontalAlignment="Center" IsEnabled="{x:Bind CanPair(IsPaired, IsConnectable), Mode=OneWay}">
                                     Pair
                                 </Button>
                             </StackPanel>


### PR DESCRIPTION
Stop using restricted services. Stop querying for battery level in Discovery page. Grey out the pair button for devices that are already paired.