### PR TITLE
Release references

### DIFF
--- a/BluetoothLEExplorer/BluetoothLEExplorer/App.xaml.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/App.xaml.cs
@@ -66,7 +66,7 @@ namespace BluetoothLEExplorer
                     }
                 }
 
-                GattSampleContext.Context.ReleaseAllReferences();
+                GattSampleContext.Context.ReleaseAllResources();
 
                 deferral.Complete();
             }

--- a/BluetoothLEExplorer/BluetoothLEExplorer/App.xaml.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/App.xaml.cs
@@ -66,6 +66,8 @@ namespace BluetoothLEExplorer
                     }
                 }
 
+                GattSampleContext.Context.ReleaseAllReferences();
+
                 deferral.Complete();
             }
             catch(Exception ex)

--- a/BluetoothLEExplorer/BluetoothLEExplorer/BluetoothLEExplorer.csproj
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/BluetoothLEExplorer.csproj
@@ -110,6 +110,7 @@
     <Compile Include="CustomControls\GattLocalCharacteristicControl.xaml.cs">
       <DependentUpon>GattLocalCharacteristicControl.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Models\DisposableObservableCollection.cs" />
     <Compile Include="Models\GattSampleContext.cs" />
     <Compile Include="Models\HidHelper.cs" />
     <Compile Include="Models\ObservableBluetoothLEDevice.cs" />

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Models/DisposableObservableCollection.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Models/DisposableObservableCollection.cs
@@ -1,0 +1,63 @@
+﻿// <copyright file="ObservableBluetoothLEDevice.cs" company="Microsoft Corporation">
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+//----------------------------------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Collections.ObjectModel;
+
+namespace BluetoothLEExplorer.Models
+{
+    /// <summary>
+    /// Helper collection class that disposes of items when they are removed
+    /// </summary>
+    public class DisposableObservableCollection<T> : ObservableCollection<T>, IDisposable where T : IDisposable
+    {
+        public void Dispose()
+        {
+            this.ToList().ForEach(disposable => disposable.Dispose());
+        }
+
+        new public void Clear()
+        {
+            var temp = this.ToList();
+            base.Clear();
+            temp.ForEach(disposable => disposable.Dispose());
+        }
+
+        new public void ClearItems()
+        {
+            var temp = this.ToList();
+            base.ClearItems();
+            temp.ForEach(disposable => disposable.Dispose());
+        }
+
+        new public bool Remove(T item)
+        {
+            T temp = item;
+            bool result = base.Remove(item);
+            if (result)
+            {
+                item.Dispose();
+            }
+            return result;
+        }
+
+        new public void RemoveAt(int index)
+        {
+            T temp = this.ElementAt(index);
+            base.RemoveAt(index);
+            temp.Dispose();
+        }
+
+        new public void RemoveItem(int index)
+        {
+            T temp = this.ElementAt(index);
+            base.RemoveItem(index);
+            temp.Dispose();
+        }
+    }
+}

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Models/GattSampleContext.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Models/GattSampleContext.cs
@@ -44,7 +44,7 @@ namespace BluetoothLEExplorer.Models
         /// <summary>
         /// Gets or sets the list of available bluetooth devices
         /// </summary>
-        public ObservableCollection<ObservableBluetoothLEDevice> BluetoothLEDevices { get; set; } = new ObservableCollection<ObservableBluetoothLEDevice>();
+        public DisposableObservableCollection<ObservableBluetoothLEDevice> BluetoothLEDevices { get; set; } = new DisposableObservableCollection<ObservableBluetoothLEDevice>();
 
         /// <summary>
         /// Gets or sets the selected bluetooth device
@@ -252,7 +252,7 @@ namespace BluetoothLEExplorer.Models
                 IsCentralRoleSupported = false;
             }
             else
-            { 
+            {
                 IsPeripheralRoleSupported = adapter.IsPeripheralRoleSupported;
                 IsCentralRoleSupported = adapter.IsCentralRoleSupported;
             }
@@ -303,7 +303,7 @@ namespace BluetoothLEExplorer.Models
             {
                 DevNodeLock.Release();
             }
-            
+
         }
 
         private async void DevNodeWatcher_Updated(DeviceWatcher sender, DeviceInformationUpdate args)
@@ -318,7 +318,7 @@ namespace BluetoothLEExplorer.Models
             {
                 DevNodeLock.Release();
             }
-            
+
             if(dev != null)
             {
                 dev.Update(args);
@@ -335,6 +335,38 @@ namespace BluetoothLEExplorer.Models
             // Add : delimiters to raw address
             var list = Enumerable.Range(0, addr.Length / 2).Select(i => addr.Substring(i * 2, 2)).ToList();
             return string.Join(":", list);
+        }
+
+        /// <summary>
+        /// Clears all devices
+        /// </summary>
+        public void ClearAllDevices()
+        {
+            try
+            {
+                BluetoothLEDevicesLock.Wait();
+                BluetoothLEDevices.Clear();
+            }
+            finally
+            {
+                BluetoothLEDevicesLock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Release all references without clearing all devices
+        /// </summary>
+        public void ReleaseAllReferences()
+        {
+            try
+            {
+                BluetoothLEDevicesLock.Wait();
+                BluetoothLEDevices.Dispose();
+            }
+            finally
+            {
+                BluetoothLEDevicesLock.Release();
+            }
         }
 
         /// <summary>
@@ -400,7 +432,7 @@ namespace BluetoothLEExplorer.Models
             advertisementWatcher = new BluetoothLEAdvertisementWatcher();
             advertisementWatcher.Received += AdvertisementWatcher_Received;
 
-            BluetoothLEDevices.Clear();
+            ClearAllDevices();
 
             deviceWatcher.Start();
             advertisementWatcher.Start();
@@ -514,8 +546,8 @@ namespace BluetoothLEExplorer.Models
                 if (sender == deviceWatcher)
                 {
                     ObservableBluetoothLEDevice dev;
-                        
-                    // Need to lock as another DeviceWatcher might be modifying BluetoothLEDevices 
+
+                    // Need to lock as another DeviceWatcher might be modifying BluetoothLEDevices
                     try
                     {
                         await BluetoothLEDevicesLock.WaitAsync();
@@ -539,10 +571,10 @@ namespace BluetoothLEExplorer.Models
                     {
                         BluetoothLEDevicesLock.Release();
                     }
-                        
+
                     if(addNewDI == true)
                     {
-                        try 
+                        try
                         {
                             await BluetoothLEDevicesLock.WaitAsync();
                             di = unusedDevices.FirstOrDefault(device => device.Id == deviceInfoUpdate.Id);
@@ -579,7 +611,7 @@ namespace BluetoothLEExplorer.Models
         private async void DeviceWatcher_Removed(DeviceWatcher sender, DeviceInformationUpdate deviceInfoUpdate)
         {
             try
-            { 
+            {
                 // Protect against race condition if the task runs after the app stopped the deviceWatcher.
                 if (sender == deviceWatcher)
                 {
@@ -587,7 +619,7 @@ namespace BluetoothLEExplorer.Models
 
                     try
                     {
-                        // Need to lock as another DeviceWatcher might be modifying BluetoothLEDevices 
+                        // Need to lock as another DeviceWatcher might be modifying BluetoothLEDevices
                         await BluetoothLEDevicesLock.WaitAsync();
 
                         // Find the corresponding DeviceInformation in the collection and remove it.
@@ -615,7 +647,7 @@ namespace BluetoothLEExplorer.Models
                     {
                         BluetoothLEDevicesLock.Release();
                     }
-                    
+
                 }
             }
             catch (Exception ex)
@@ -656,10 +688,10 @@ namespace BluetoothLEExplorer.Models
                     (bool)dev.DeviceInfo.Properties["System.Devices.Aep.IsConnected"])) ||
                 ((dev.DeviceInfo.Properties.Keys.Contains("System.Devices.Aep.IsPaired") &&
                     (bool)dev.DeviceInfo.Properties["System.Devices.Aep.IsPaired"]));
-                
+
             if (shouldDisplay)
             {
-                // Need to lock as another DeviceWatcher might be modifying BluetoothLEDevices 
+                // Need to lock as another DeviceWatcher might be modifying BluetoothLEDevices
                 try
                 {
                     await BluetoothLEDevicesLock.WaitAsync();
@@ -685,6 +717,7 @@ namespace BluetoothLEExplorer.Models
                 {
                     await BluetoothLEDevicesLock.WaitAsync();
                     unusedDevices.Add(deviceInfo);
+                    dev.Dispose();
                 }
                 finally
                 {

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Models/GattSampleContext.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Models/GattSampleContext.cs
@@ -354,9 +354,9 @@ namespace BluetoothLEExplorer.Models
         }
 
         /// <summary>
-        /// Release all references without clearing all devices
+        /// Release all resources without clearing all devices
         /// </summary>
-        public void ReleaseAllReferences()
+        public void ReleaseAllResources()
         {
             try
             {

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableBluetoothLEDevice.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableBluetoothLEDevice.cs
@@ -664,7 +664,7 @@ namespace BluetoothLEExplorer.Models
                 }
                 catch
                 {
-                    Name = "Exception";
+                    Name = "Unknown (exception)";
                 }
 
             });

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableGattCharacteristics.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableGattCharacteristics.cs
@@ -321,8 +321,8 @@ namespace BluetoothLEExplorer.Models
             Characteristic = characteristic;
             Parent = parent;
 
-            Name = GattCharacteristicUuidHelper.ConvertUuidToName(Characteristic.Uuid);
-            UUID = Characteristic.Uuid.ToString();
+            Name = GattCharacteristicUuidHelper.ConvertUuidToName(characteristic.Uuid);
+            UUID = characteristic.Uuid.ToString();
         }
 
         public async Task Initialize()
@@ -375,7 +375,7 @@ namespace BluetoothLEExplorer.Models
         {
             try
             {
-                GattReadResult result = await Characteristic.ReadValueAsync(
+                GattReadResult result = await characteristic.ReadValueAsync(
                     BluetoothLEExplorer.Services.SettingsServices.SettingsService.Instance.UseCaching ? BluetoothCacheMode.Cached : BluetoothCacheMode.Uncached);
 
                 if (result.Status == GattCommunicationStatus.Success)
@@ -394,7 +394,7 @@ namespace BluetoothLEExplorer.Models
             catch (Exception ex)
             {
                 Debug.WriteLine("Exception: " + ex.Message);
-                Value = "Unknown (exception)";
+                Value = "Unknown (exception: " + ex.Message + ")";
             }
         }
 
@@ -428,7 +428,7 @@ namespace BluetoothLEExplorer.Models
 
             try
             {
-                GattDescriptorsResult result = await Characteristic.GetDescriptorsAsync(Services.SettingsServices.SettingsService.Instance.UseCaching ? BluetoothCacheMode.Cached : BluetoothCacheMode.Uncached);
+                GattDescriptorsResult result = await characteristic.GetDescriptorsAsync(Services.SettingsServices.SettingsService.Instance.UseCaching ? BluetoothCacheMode.Cached : BluetoothCacheMode.Uncached);
 
                 if (result.Status == GattCommunicationStatus.Success)
                 {
@@ -457,7 +457,7 @@ namespace BluetoothLEExplorer.Models
             catch (Exception ex)
             {
                 Debug.WriteLine(" - Exception: {0}" + ex.Message);
-                Value = "Unknown (exception)";
+                Value = "Unknown (exception: " + ex.Message + ")";
             }
         }
 
@@ -479,7 +479,7 @@ namespace BluetoothLEExplorer.Models
                 // We receive them in the ValueChanged event handler.
                 // Note that this sample configures either Indicate or Notify, but not both.
                 var result = await
-                        Characteristic.WriteClientCharacteristicConfigurationDescriptorAsync(
+                        characteristic.WriteClientCharacteristicConfigurationDescriptorAsync(
                             GattClientCharacteristicConfigurationDescriptorValue.Indicate);
                 if (result == GattCommunicationStatus.Success)
                 {
@@ -536,7 +536,7 @@ namespace BluetoothLEExplorer.Models
                 // We receive them in the ValueChanged event handler.
                 // Note that this sample configures either Indicate or Notify, but not both.
                 var result = await
-                        Characteristic.WriteClientCharacteristicConfigurationDescriptorAsync(
+                        characteristic.WriteClientCharacteristicConfigurationDescriptorAsync(
                             GattClientCharacteristicConfigurationDescriptorValue.None);
                 if (result == GattCommunicationStatus.Success)
                 {
@@ -586,7 +586,7 @@ namespace BluetoothLEExplorer.Models
                 // We receive them in the ValueChanged event handler.
                 // Note that this sample configures either Indicate or Notify, but not both.
                 var result = await
-                        Characteristic.WriteClientCharacteristicConfigurationDescriptorAsync(
+                        characteristic.WriteClientCharacteristicConfigurationDescriptorAsync(
                             GattClientCharacteristicConfigurationDescriptorValue.Notify);
                 if (result == GattCommunicationStatus.Success)
                 {
@@ -643,7 +643,7 @@ namespace BluetoothLEExplorer.Models
                 // We receive them in the ValueChanged event handler.
                 // Note that this sample configures either Indicate or Notify, but not both.
                 var result = await
-                        Characteristic.WriteClientCharacteristicConfigurationDescriptorAsync(
+                        characteristic.WriteClientCharacteristicConfigurationDescriptorAsync(
                             GattClientCharacteristicConfigurationDescriptorValue.None);
                 if (result == GattCommunicationStatus.Success)
                 {
@@ -715,15 +715,15 @@ namespace BluetoothLEExplorer.Models
 
             GattPresentationFormat format = null;
 
-            if (Characteristic.PresentationFormats.Count > 0)
+            if (characteristic.PresentationFormats.Count > 0)
             {
-                format = Characteristic.PresentationFormats[0];
+                format = characteristic.PresentationFormats[0];
             }
 
             // Determine what to set our DisplayType to
             if (format == null && DisplayType == DisplayTypes.NotSet)
             {
-                if (Name == "DeviceName")
+                if (name == "DeviceName")
                 {
                     // All devices have DeviceName so this is a special case.
                     DisplayType = DisplayTypes.UTF8;

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableGattCharacteristics.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableGattCharacteristics.cs
@@ -394,7 +394,7 @@ namespace BluetoothLEExplorer.Models
             catch (Exception ex)
             {
                 Debug.WriteLine("Exception: " + ex.Message);
-                Value = "Exception!";
+                Value = "Unknown (exception)";
             }
         }
 
@@ -457,7 +457,7 @@ namespace BluetoothLEExplorer.Models
             catch (Exception ex)
             {
                 Debug.WriteLine(" - Exception: {0}" + ex.Message);
-                Value = "Exception";
+                Value = "Unknown (exception)";
             }
         }
 

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableGattDescriptors.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableGattDescriptors.cs
@@ -170,8 +170,8 @@ namespace BluetoothLEExplorer.Models
 
         public async Task Initialize()
         {
-            Name = GattDescriptorUuidHelper.ConvertUuidToName(Descriptor.Uuid);
-            UUID = Descriptor.Uuid.ToString();
+            Name = GattDescriptorUuidHelper.ConvertUuidToName(descriptor.Uuid);
+            UUID = descriptor.Uuid.ToString();
 
             await ReadValueAsync();
             PropertyChanged += ObservableGattDescriptors_PropertyChanged;
@@ -202,7 +202,7 @@ namespace BluetoothLEExplorer.Models
         {
             try
             {
-                GattReadResult result = await Descriptor.ReadValueAsync(
+                GattReadResult result = await descriptor.ReadValueAsync(
                     Services.SettingsServices.SettingsService.Instance.UseCaching ? BluetoothCacheMode.Cached : BluetoothCacheMode.Uncached);
 
                 if (result.Status == GattCommunicationStatus.Success)
@@ -221,7 +221,7 @@ namespace BluetoothLEExplorer.Models
             catch (Exception ex)
             {
                 Debug.WriteLine("Exception: " + ex.Message);
-                Value = "Unknown (exception)";
+                Value = "Unknown (exception: " + ex.Message + ")";
             }
         }
 

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableGattDescriptors.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableGattDescriptors.cs
@@ -166,10 +166,14 @@ namespace BluetoothLEExplorer.Models
         {
             Descriptor = descriptor;
             Parent = parent;
+        }
+
+        public async Task Initialize()
+        {
             Name = GattDescriptorUuidHelper.ConvertUuidToName(Descriptor.Uuid);
             UUID = Descriptor.Uuid.ToString();
 
-            ReadValueAsync();
+            await ReadValueAsync();
             PropertyChanged += ObservableGattDescriptors_PropertyChanged;
         }
 
@@ -194,7 +198,7 @@ namespace BluetoothLEExplorer.Models
         /// <summary>
         /// Reads the value of the Characteristic
         /// </summary>
-        public async void ReadValueAsync()
+        public async Task ReadValueAsync()
         {
             try
             {

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableGattDescriptors.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableGattDescriptors.cs
@@ -221,7 +221,7 @@ namespace BluetoothLEExplorer.Models
             catch (Exception ex)
             {
                 Debug.WriteLine("Exception: " + ex.Message);
-                Value = "Exception!";
+                Value = "Unknown (exception)";
             }
         }
 

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableGattDeviceService.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableGattDeviceService.cs
@@ -278,7 +278,7 @@ namespace BluetoothLEExplorer.Models
             catch (Exception ex)
             {
                 Debug.WriteLine("getAllCharacteristics: Exception - {0}" + ex.Message);
-                Name = "Exception";
+                Name = "Unknown (exception)";
             }
             finally
             {

--- a/BluetoothLEExplorer/BluetoothLEExplorer/ViewModels/DeviceServicesPageViewModel.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/ViewModels/DeviceServicesPageViewModel.cs
@@ -60,7 +60,7 @@ namespace BluetoothLEExplorer.ViewModels
                 Set(ref errorText, value, "ErrorText");
             }
         }
-        
+
         /// <summary>
         /// Source for <see cref="SelectedCharacteristic"/>
         /// </summary>
@@ -104,7 +104,7 @@ namespace BluetoothLEExplorer.ViewModels
         public override async Task OnNavigatedToAsync(object parameter, NavigationMode mode, IDictionary<string, object> suspensionState)
         {
             await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(
-                Windows.UI.Core.CoreDispatcherPriority.Normal, 
+                Windows.UI.Core.CoreDispatcherPriority.Normal,
                 () =>
             {
             });
@@ -136,6 +136,18 @@ namespace BluetoothLEExplorer.ViewModels
         {
             args.Cancel = false;
             await Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Reenumerate all services
+        /// </summary>
+        public async void Refresh()
+        {
+            Views.Busy.SetBusy(true, "Reenumerating Services for  " + Device.Name);
+
+            await Device.Connect();
+
+            Views.Busy.SetBusy(false);
         }
     }
 }

--- a/BluetoothLEExplorer/BluetoothLEExplorer/ViewModels/DiscoverViewModel.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/ViewModels/DiscoverViewModel.cs
@@ -337,6 +337,7 @@ namespace BluetoothLEExplorer.ViewModels
 
             Context.BluetoothLEDevices.CollectionChanged += BluetoothLEDevices_CollectionChanged;
             GridFilter = "";
+            Context.ReleaseAllReferences();
             UpdateDeviceList();
 
             await Task.CompletedTask;

--- a/BluetoothLEExplorer/BluetoothLEExplorer/ViewModels/DiscoverViewModel.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/ViewModels/DiscoverViewModel.cs
@@ -337,7 +337,7 @@ namespace BluetoothLEExplorer.ViewModels
 
             Context.BluetoothLEDevices.CollectionChanged += BluetoothLEDevices_CollectionChanged;
             GridFilter = "";
-            Context.ReleaseAllReferences();
+            Context.ReleaseAllResources();
             UpdateDeviceList();
 
             await Task.CompletedTask;

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Views/DeviceServicesPage.xaml
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Views/DeviceServicesPage.xaml
@@ -107,7 +107,7 @@
                     <Run Text="{x:Bind ViewModel.Device.IsConnected, Mode=OneWay}" />
                     </TextBlock>
                 </Border>
-                <Button Name="RefreshButton" Click="{x:Bind ViewModel.Device.Connect}">
+                <Button Name="RefreshButton" Click="{x:Bind ViewModel.Refresh}">
                     Refresh
                 </Button>
             </StackPanel>


### PR DESCRIPTION
I am releasing references by calling dispose() on BluetoothLEDevice and GattDeviceService when appropriate:

- Upon closing the app: App_Suspending releases all BluetoothLEDevice references and GattDeviceService references
- Upon navigating to the Discovery page: all BluetoothLEDevice references and GattDeviceService references
- Upon refreshing/connecting to the Device Services page: all GattDeviceServices previously associated with the selected device are disposed

This allows Windows to disconnect from the previously selected device. Additionally, I added locks and rewrote throw statements so that Services/Characteristics/Descriptors failed gracefully if the underlying device was disconnected.