### PR TITLE
Make UI changes

### DIFF
--- a/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableBluetoothLEDevice.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableBluetoothLEDevice.cs
@@ -461,10 +461,13 @@ namespace BluetoothLEExplorer.Models
             {
                 bluetoothLEDeviceLock.Release();
             }
-            temp.ConnectionStatusChanged -= BluetoothLEDevice_ConnectionStatusChanged;
-            temp.NameChanged -= BluetoothLEDevice_NameChanged;
-            temp.Dispose();
 
+            if (temp != null)
+            {
+                temp.ConnectionStatusChanged -= BluetoothLEDevice_ConnectionStatusChanged;
+                temp.NameChanged -= BluetoothLEDevice_NameChanged;
+                temp.Dispose();
+            }
             IsConnected = false;
         }
 
@@ -561,7 +564,7 @@ namespace BluetoothLEExplorer.Models
                     {
                         Debug.WriteLine(debugMsg + "Previously connected, not calling BluetoothLEDevice.FromIdAsync");
                     }
-                    
+
                     Debug.WriteLine(debugMsg + "BluetoothLEDevice is " + BluetoothLEDevice.Name);
 
                     Name = bluetoothLEDevice.Name;

--- a/BluetoothLEExplorer/BluetoothLEExplorer/ViewModels/CharacteristicPageViewModel.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/ViewModels/CharacteristicPageViewModel.cs
@@ -643,6 +643,7 @@ namespace BluetoothLEExplorer.ViewModels
                     {
                         NotifyUser.Insert(0, "Unable to write data - Protocol error");
                     }
+                    ValueToWrite = String.Empty;
                 }
                 catch (Exception ex) when ((uint)ex.HResult == 0x80650003 || (uint)ex.HResult == 0x80070005)
                 {

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Views/CharacteristicPage.xaml
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Views/CharacteristicPage.xaml
@@ -211,7 +211,7 @@
                 <RelativePanel VerticalAlignment="Center" Visibility="{x:Bind ViewModel.CharacteristicValueVisible, Converter={StaticResource VisibleWhenTrueConverter}}" >
                     <TextBlock Name="ReadValueText" Text="Read Value: " VerticalAlignment="Center" Width="100" Height="32" Margin="0,5,5,5"/>
                     <Border Name="Value" Background="LightGray" RelativePanel.RightOf="ReadValueText" RelativePanel.AlignVerticalCenterWith="ReadValueText" MinWidth="75" Height="32" Margin="5" >
-                        <TextBlock Text="{x:Bind ViewModel.Characteristic.Value, Mode=OneWay}" VerticalAlignment="Center"  Margin="5,0" TextWrapping="WrapWholeWords"/>
+                        <TextBlock Text="{x:Bind ViewModel.Characteristic.Value, Mode=OneWay}" VerticalAlignment="Center"  Margin="5,0" TextWrapping="Wrap" IsTextSelectionEnabled="True" HorizontalAlignment="Stretch"/>
                     </Border>
                     <Button Name="ReadAgainButton" Content="Read Again" Click="{x:Bind ViewModel.Characteristic.ReadValueAsync}" Visibility="{x:Bind ViewModel.CharacteristicCanBeRead, Converter={StaticResource VisibleWhenTrueConverter}}" Margin="5" Width="100" Height="32" d:LayoutOverrides="LeftMargin, RightMargin" />
 
@@ -228,10 +228,9 @@
 
             <RelativePanel Grid.Row="2" VerticalAlignment="Center" Visibility="{x:Bind ViewModel.CharacteristicCanWrite, Converter={StaticResource VisibleWhenTrueConverter}}">
                 <TextBlock x:Name="WriteValueText" Text="Write Value: " Margin="0,5,5,5" VerticalAlignment="Center" Width="100" />
-                <TextBox x:Name="WriteValue" Text="{x:Bind ViewModel.ValueToWrite, Mode=TwoWay}" VerticalAlignment="Center" Width="100" Margin="5" 
-                         RelativePanel.RightOf="WriteValueText" TextChanging="WriteValue_TextChanging" 
-                         />
-                <Button x:Name="WriteButton" Content="Write" Click="{x:Bind ViewModel.WriteValue}" Margin="5" RelativePanel.RightOf="WriteValue" />
+                <TextBox x:Name="WriteValue" Text="{x:Bind ViewModel.ValueToWrite, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Center" HorizontalAlignment="Stretch" Margin="5" 
+                         RelativePanel.RightOf="WriteValueText" TextChanging="WriteValue_TextChanging" KeyUp="DetectEnter_Keydown"/>
+                <Button x:Name="WriteButton" Content="Write" Click="{x:Bind ViewModel.WriteValue}" Margin="5" RelativePanel.RightOf="WriteValue"/>
                 <!-- The radio buttons need to be in different groups because they are all bound to the same property, so it takes care of which ones stays on vs off. If there is no group then the stackpanel container -->
                 <!-- groups them and it conflicts with the value converter -->
                 <StackPanel Name="WriteType" Orientation="Horizontal" Margin="5">

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Views/CharacteristicPage.xaml.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Views/CharacteristicPage.xaml.cs
@@ -63,5 +63,13 @@ namespace BluetoothLEExplorer.Views
         {
             ViewModel.SelectedDescriptor = (ObservableGattDescriptors)e.ClickedItem;
         }
+
+        public void DetectEnter_Keydown(object sender, Windows.UI.Xaml.Input.KeyRoutedEventArgs e)
+        {
+            if (e.Key == Windows.System.VirtualKey.Enter)
+            {
+                ViewModel.WriteValue();
+            }
+        }
     }
 }

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Views/CharacteristicPage.xaml.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Views/CharacteristicPage.xaml.cs
@@ -64,6 +64,9 @@ namespace BluetoothLEExplorer.Views
             ViewModel.SelectedDescriptor = (ObservableGattDescriptors)e.ClickedItem;
         }
 
+        /// <summary>
+        /// Detect when a user presses enter and writes the value to the selected GattCharacterisitc.
+        /// </summary>
         public void DetectEnter_Keydown(object sender, Windows.UI.Xaml.Input.KeyRoutedEventArgs e)
         {
             if (e.Key == Windows.System.VirtualKey.Enter)

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Views/DeviceServicesPage.xaml
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Views/DeviceServicesPage.xaml
@@ -89,7 +89,7 @@
 
             <StackPanel Grid.Row="0">
                 <TextBlock Text="{x:Bind ViewModel.Device.ErrorText}" Visibility="{x:Bind ViewModel.Device.ErrorText, Converter={StaticResource VisibleWhenBlankConverter}}" />
-                <TextBlock>
+                <TextBlock IsTextSelectionEnabled="True">
                     <Run Text="BT Address: " />
                     <Run Text="{x:Bind ViewModel.Device.BluetoothAddressAsString, Mode=OneWay}"/>
                 </TextBlock>

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Views/Discover.xaml
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Views/Discover.xaml
@@ -9,7 +9,7 @@
       xmlns:local="using:BluetoothLEExplorer.Views"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:converters="using:Template10.Converters"
-      xmlns:vm="using:BluetoothLEExplorer.ViewModels" mc:Ignorable="d" 
+      xmlns:vm="using:BluetoothLEExplorer.ViewModels" mc:Ignorable="d"
       xmlns:models="using:BluetoothLEExplorer.Models"
       xmlns:release="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,5)"
       xmlns:insider="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
@@ -114,8 +114,8 @@
                 </VisualState>
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
-        
-        
+
+
 
         <controls:PageHeader x:Name="pageHeader" RelativePanel.AlignLeftWithPanel="True"
                              RelativePanel.AlignRightWithPanel="True"
@@ -134,10 +134,10 @@
             <TextBlock Text="Central role is not supported on this device" />
         </RelativePanel>
 
-        <ProgressBar x:Name="progressBar" 
+        <ProgressBar x:Name="progressBar"
                      IsEnabled="{x:Bind ViewModel.IsEnumerating, Mode=OneWay }"
                      IsIndeterminate="{x:Bind ViewModel.IsEnumerating, Mode=OneWay }"
-                     RelativePanel.Below="pageHeader" 
+                     RelativePanel.Below="pageHeader"
                      RelativePanel.AlignLeftWithPanel="True" RelativePanel.AlignRightWithPanel="True"
                      Visibility="{x:Bind ViewModel.IsCentralRoleSupported, Converter={StaticResource VisibleWhenTrueConverter}}"/>
 
@@ -153,20 +153,20 @@
                     <TextBlock Text="Enumeration finished" Visibility="{x:Bind ViewModel.EnumerationFinished, Mode=OneWay, Converter={StaticResource VisibleWhenTrueConverter}}" Margin="10,0,0,0" VerticalAlignment="Center" />
                 </StackPanel>
                 <CheckBox Content="Continuous Enumeration" IsChecked="{x:Bind ViewModel.ContinuousEnumeration, Mode=TwoWay}" />
-                
+
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="0,5">
                     <TextBlock Text="Filter: " VerticalAlignment="Center" Margin="0, 0, 5, 0"/>
                     <TextBox Text="{Binding GridFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"  />
                 </StackPanel>
-                            
+
                 <TextBlock>
                     <Run Text="Total Device Count:" />
                     <Run Text="{x:Bind ViewModel.Context.BluetoothLEDevices.Count, Mode=OneWay}" />
-                </TextBlock> 
+                </TextBlock>
             </StackPanel>
 
-            <GridView Grid.Row="1" x:Name="DevicesListView" 
-                ItemsSource="{x:Bind ViewModel.DeviceList, Mode=OneWay}"   
+            <GridView Grid.Row="1" x:Name="DevicesListView"
+                ItemsSource="{x:Bind ViewModel.DeviceList, Mode=OneWay}"
                 SelectedItem="{x:Bind ViewModel.SelectedDevice, Mode=TwoWay}" Margin="0,20,0,0">
                 <GridView.ItemsPanel>
                     <ItemsPanelTemplate>
@@ -200,7 +200,7 @@
                                     <ColumnDefinition Width="*" />
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
-                                
+
                                 <Border BorderBrush="Black" BorderThickness="2" >
                                     <Image Grid.Column="0" x:Name="Glyph" Source="{Binding Glyph}"  Height="40" Width="40" Margin="5" />
                                 </Border>
@@ -214,7 +214,7 @@
                                 <TextBlock TextWrapping="Wrap">
                                     Name: <Run Text="{x:Bind Name, Mode=OneWay}" />
                                 </TextBlock>
-                                <TextBlock TextWrapping="WrapWholeWords" Foreground="Black">
+                                <TextBlock TextWrapping="WrapWholeWords" Foreground="Black" IsTextSelectionEnabled="True">
                                     BT Address: <Run Text="{x:Bind BluetoothAddressAsString, Mode=OneTime}" />
                                 </TextBlock>
                                 <TextBlock Foreground="Black">
@@ -226,7 +226,7 @@
                                 <TextBlock Foreground="Black">
                                     Paired: <Run Text="{x:Bind IsPaired, Mode=OneWay}"/>
                                 </TextBlock>
-                                <TextBlock Visibility="{x:Bind ServiceCount, Converter={StaticResource CollapsedWhenZero}}" Foreground="Black" > 
+                                <TextBlock Visibility="{x:Bind ServiceCount, Converter={StaticResource CollapsedWhenZero}}" Foreground="Black" >
                                     Service Count: <Run Text="{x:Bind ServiceCount, Mode=OneWay}"/>
                                 </TextBlock>
                                 <TextBlock>


### PR DESCRIPTION
Made a bunch of changes to the characteristic page:
- Made the write value clear when the value gets sent
- Made hitting enter also send the value
- Made the read value and write value text box's expand with larger inputs
- Made the read value selectable (to copy)

Made the Bluetooth address in both the Discovery page and the Device Services page selectable.