### PR TITLE
Remove locks on BluetoothLEDevice and GattDeviceService

### DIFF
--- a/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableBluetoothLEDevice.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableBluetoothLEDevice.cs
@@ -89,11 +89,6 @@ namespace BluetoothLEExplorer.Models
         }
 
         /// <summary>
-        /// Lock around the <see cref="BluetoothLEDevice"/>
-        /// </summary>
-        private SemaphoreSlim bluetoothLEDeviceLock = new SemaphoreSlim(1, 1);
-
-        /// <summary>
         /// Source for <see cref="Glyph"/>
         /// </summary>
         private BitmapImage glyph;
@@ -449,18 +444,8 @@ namespace BluetoothLEExplorer.Models
         {
             Services.Clear();
             var temp = bluetoothLEDevice;
-            try
-            {
-                bluetoothLEDeviceLock.Wait();
-                if (bluetoothLEDevice != null)
-                {
-                    BluetoothLEDevice = null;
-                }
-            }
-            finally
-            {
-                bluetoothLEDeviceLock.Release();
-            }
+
+            BluetoothLEDevice = null;
 
             if (temp != null)
             {
@@ -538,7 +523,6 @@ namespace BluetoothLEExplorer.Models
                 Debug.WriteLine(debugMsg + "In UI thread");
                 try
                 {
-                    await bluetoothLEDeviceLock.WaitAsync();
                     if (bluetoothLEDevice == null)
                     {
                         Debug.WriteLine(debugMsg + "Calling BluetoothLEDevice.FromIdAsync");
@@ -635,10 +619,6 @@ namespace BluetoothLEExplorer.Models
 
                     // Debugger break here so we can catch unknown exceptions
                     Debugger.Break();
-                }
-                finally
-                {
-                    bluetoothLEDeviceLock.Release();
                 }
             });
 

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableGattDeviceService.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableGattDeviceService.cs
@@ -46,24 +46,14 @@ namespace BluetoothLEExplorer.Models
             }
         }
 
-        /// <summary>
-        /// Lock around the <see cref="Service"/>.
-        /// </summary>
-        SemaphoreSlim serviceLock = new SemaphoreSlim(1, 1);
-
         public void Dispose()
         {
             var temp = service;
-            try
+            Service = null;
+            if (temp != null)
             {
-                serviceLock.Wait();
-                Service = null;
+                temp.Dispose();
             }
-            finally
-            {
-                serviceLock.Release();
-            }
-            temp.Dispose();
         }
 
         /// <summary>
@@ -181,15 +171,7 @@ namespace BluetoothLEExplorer.Models
         /// <param name="service">The service this class wraps</param>
         public ObservableGattDeviceService(GattDeviceService service)
         {
-            try
-            {
-                serviceLock.Wait();
-                Service = service;
-            }
-            finally
-            {
-                serviceLock.Release();
-            }
+            Service = service;
             Name = GattServiceUuidHelper.ConvertUuidToName(service.Uuid);
             UUID = service.Uuid.ToString();
         }
@@ -370,8 +352,6 @@ namespace BluetoothLEExplorer.Models
 
             try
             {
-                await serviceLock.WaitAsync();
-
                 // Request the necessary access permissions for the service and abort
                 // if permissions are denied.
                 GattOpenStatus status = await service.OpenAsync(GattSharingMode.SharedReadAndWrite);
@@ -416,10 +396,6 @@ namespace BluetoothLEExplorer.Models
             {
                 Debug.WriteLine("getAllCharacteristics: Exception - {0}" + ex.Message);
                 Name += " - Exception: " + ex.Message;
-            }
-            finally
-            {
-                serviceLock.Release();
             }
         }
 


### PR DESCRIPTION
These locks are for protecting against null pointer accesses. They don't allow bluetoothledevice and gattdeviceservice to be disposed of/nulled out while they are being initialized. However an important thread (I think the UI thread) calls dispose and having dispose wait on initializing can take a long time. Additionally, dispose can't be made async (for firing and forgetting). So now there are null pointer accesses but any time it could happen is surrounded by try catch blocks which just print that there was a null pointer access.