### PR TITLE
Create new bluetoothledevice upon refresh

### DIFF
--- a/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableBluetoothLEDevice.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableBluetoothLEDevice.cs
@@ -467,6 +467,25 @@ namespace BluetoothLEExplorer.Models
             }
         }
 
+        private ulong gattServicesChangedInstances = 0;
+
+        public ulong GattServicesChangedInstances
+        {
+            get
+            {
+                return gattServicesChangedInstances;
+            }
+
+            private set
+            {
+                if (gattServicesChangedInstances != value)
+                {
+                    gattServicesChangedInstances = value;
+                    OnPropertyChanged(new PropertyChangedEventArgs("GattServicesChangedInstances"));
+                }
+            }
+        }
+
         /// <summary>
         /// Releases references to Services and the BluetoothLEDevice
         /// </summary>
@@ -550,15 +569,9 @@ namespace BluetoothLEExplorer.Models
                 Debug.WriteLine(debugMsg + "In UI thread");
                 try
                 {
-                    if (bluetoothLEDevice == null)
-                    {
-                        Debug.WriteLine(debugMsg + "Calling BluetoothLEDevice.FromIdAsync");
-                        BluetoothLEDevice = await BluetoothLEDevice.FromIdAsync(DeviceInfo.Id);
-                    }
-                    else
-                    {
-                        Debug.WriteLine(debugMsg + "Previously connected, not calling BluetoothLEDevice.FromIdAsync");
-                    }
+                    Dispose();
+                    Debug.WriteLine(debugMsg + "Calling BluetoothLEDevice.FromIdAsync");
+                    BluetoothLEDevice = await BluetoothLEDevice.FromIdAsync(DeviceInfo.Id);
 
                     if (bluetoothLEDevice == null)
                     {
@@ -575,6 +588,7 @@ namespace BluetoothLEExplorer.Models
                         // Setup our event handlers and view model properties
                         BluetoothLEDevice.ConnectionStatusChanged += BluetoothLEDevice_ConnectionStatusChanged;
                         BluetoothLEDevice.NameChanged += BluetoothLEDevice_NameChanged;
+                        GattServicesChangedInstances = 0;
                         BluetoothLEDevice.GattServicesChanged += BluetoothLEDevice_GattServicesChanged;
 
                         IsPaired = DeviceInfo.Pairing.IsPaired;
@@ -623,7 +637,6 @@ namespace BluetoothLEExplorer.Models
 
             // Get all the services for this device
             var result = await BluetoothLEDevice.GetGattServicesAsync(cacheMode);
-            var returnedServices = new DisposableObservableCollection<ObservableGattDeviceService>();
 
             if (result.Status == GattCommunicationStatus.Success)
             {
@@ -635,13 +648,14 @@ namespace BluetoothLEExplorer.Models
                         var temp = new ObservableGattDeviceService(serv);
                         // This isn't awaited so that the user can disconnect while the services are still being enumerated
                         temp.Initialize();
-                        returnedServices.Add(temp);
+                        Services.Add(temp);
                     }
                     else
                     {
                         serv.Dispose();
                     }
                 }
+                ServiceCount = Services.Count();
 
                 succeeded = true;
             }
@@ -660,14 +674,6 @@ namespace BluetoothLEExplorer.Models
                 string msg = "Device unreachable";
                 var messageDialog = new MessageDialog(msg, "Connection failures");
                 await messageDialog.ShowAsync();
-            }
-
-            lock (Services)
-            {
-                // In case we connected before, clear the service list and recreate it
-                Services.Clear();
-                Services = returnedServices;
-                ServiceCount = Services.Count();
             }
 
             return succeeded;
@@ -722,12 +728,13 @@ namespace BluetoothLEExplorer.Models
 
         private async void BluetoothLEDevice_GattServicesChanged(BluetoothLEDevice sender, object args)
         {
-            await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunTaskAsync(async () =>
+            await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(
+                Windows.UI.Core.CoreDispatcherPriority.Normal,
+                () =>
             {
-                // If we received a service change.  If we are in the middle of discovery services,
-                // we can ignore the service change.
-                await GetAllPrimaryServices(IsPaired ? BluetoothCacheMode.Cached : BluetoothCacheMode.Uncached);
+                GattServicesChangedInstances += 1;
             });
+            
         }
 
         /// <summary>

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Views/DeviceServicesPage.xaml
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Views/DeviceServicesPage.xaml
@@ -113,6 +113,10 @@
                     <Run Text="{x:Bind ViewModel.Device.Services.Count, Mode=OneWay}" />
                 </TextBlock>
                 <TextBlock>
+                    <Run Text="Number of service changed events:" />
+                    <Run Text="{x:Bind ViewModel.Device.GattServicesChangedInstances, Mode=OneWay}" />
+                </TextBlock>
+                <TextBlock>
                     <Run Text="Number of Advertisement Services:" />
                     <Run Text="{x:Bind ViewModel.Device.AdvertisementServiceCount, Mode=OneWay}" />
                 </TextBlock>


### PR DESCRIPTION
The app refreshes better when instead of disposing and recreating the gattdeviceservices, the app disposes and recreates the bluetoothledevice. This requires not refreshing when a gattservicechanged event happens because it happens upon first discovering the bluetoothledevice and the app can get stuck in a loop. I changed gattservicechangedevent callback to a counter and displayed said counter in device services page.