### PR TITLE
Close Bluetooth connections option

### DIFF
--- a/BluetoothLEExplorer/BluetoothLEExplorer/Services/SettingsServices/SettingsService.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Services/SettingsServices/SettingsService.cs
@@ -71,6 +71,22 @@ namespace BluetoothLEExplorer.Services.SettingsServices
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether connections should be closed upon going back to Discovery page.
+        /// </summary>
+        public bool CloseConnections
+        {
+            get
+            {
+                return helper.Read<bool>(nameof(CloseConnections), true);
+            }
+
+            set
+            {
+                helper.Write(nameof(CloseConnections), value);
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the application theme
         /// </summary>
         public ApplicationTheme AppTheme

--- a/BluetoothLEExplorer/BluetoothLEExplorer/ViewModels/DiscoverViewModel.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/ViewModels/DiscoverViewModel.cs
@@ -338,7 +338,10 @@ namespace BluetoothLEExplorer.ViewModels
 
             Context.BluetoothLEDevices.CollectionChanged += BluetoothLEDevices_CollectionChanged;
             GridFilter = "";
-            Context.ReleaseAllResources();
+            if (Services.SettingsServices.SettingsService.Instance.CloseConnections)
+            {
+                Context.ReleaseAllResources();
+            }
             UpdateDeviceList();
 
             await Task.CompletedTask;

--- a/BluetoothLEExplorer/BluetoothLEExplorer/ViewModels/SettingsPageViewModel.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/ViewModels/SettingsPageViewModel.cs
@@ -71,6 +71,7 @@ namespace BluetoothLEExplorer.ViewModels
                 RaisePropertyChanged();
             }
         }
+
         /// <summary>
         /// Gets or sets a value indicating whether caching should be used
         /// </summary>
@@ -84,6 +85,23 @@ namespace BluetoothLEExplorer.ViewModels
             set
             {
                 settings.UseCaching = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether connections should be closed upon going back to Discovery page
+        /// </summary>
+        public bool CloseConnectionsButton
+        {
+            get
+            {
+                return settings.CloseConnections;
+            }
+
+            set
+            {
+                settings.CloseConnections = value;
                 RaisePropertyChanged();
             }
         }

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Views/SettingsPage.xaml
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Views/SettingsPage.xaml
@@ -88,7 +88,7 @@
 
                         <ToggleSwitch x:Name="CloseConnectionsToggleSwitch" Header="Close Connections"
                                       IsOn="{Binding CloseConnectionsButton, Mode=TwoWay}"
-                                      OffContent="Leave Bluetooth connections open while navigating the app." OnContent="Close Bluetooth conections upon navigating to Discovery page."
+                                      OffContent="Leave Bluetooth connections open while navigating the app." OnContent="Close Bluetooth connections upon navigating to Discovery page."
                                       RelativePanel.AlignLeftWithPanel="True"
                                       RelativePanel.Below="UseCachingToggleSwitch" />
                     </RelativePanel>

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Views/SettingsPage.xaml
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Views/SettingsPage.xaml
@@ -79,12 +79,18 @@
                                       OffContent="Dark theme" OnContent="Light theme"
                                       RelativePanel.AlignLeftWithPanel="True"
                                       RelativePanel.Below="UseShellDrawnBackButtonToggleSwtich" />
-                        
+
                         <ToggleSwitch x:Name="UseCachingToggleSwitch" Header="Use Caching"
                                       IsOn="{Binding UseCachingButton, Mode=TwoWay}"
                                       OffContent="Will make over the air requests if necessary based on GattRobustCaching if supported." OnContent="Will use locally cached values where possible."
                                       RelativePanel.AlignLeftWithPanel="True"
                                       RelativePanel.Below="UseLightThemeToggleSwitch" />
+
+                        <ToggleSwitch x:Name="CloseConnectionsToggleSwitch" Header="Close Connections"
+                                      IsOn="{Binding CloseConnectionsButton, Mode=TwoWay}"
+                                      OffContent="Leave Bluetooth connections open while navigating the app." OnContent="Close Bluetooth conections upon navigating to Discovery page."
+                                      RelativePanel.AlignLeftWithPanel="True"
+                                      RelativePanel.Below="UseCachingToggleSwitch" />
                     </RelativePanel>
 
                 </ScrollViewer>


### PR DESCRIPTION
Added an option to the settings page to close/not close Bluetooth connections upon navigating to the Discovery page.