### PR TITLE
Update rssi value more slowly

### DIFF
--- a/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableBluetoothLEDevice.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Models/ObservableBluetoothLEDevice.cs
@@ -44,10 +44,10 @@ namespace BluetoothLEExplorer.Models
                     throw new InvalidOperationException("Compared objects are not ObservableBluetoothLEDevice");
                 }
 
-                // If they're equal
+                // If they're equal sort by bluetooth address
                 if(a.RSSI == b.RSSI)
                 {
-                    return 0;
+                    return a.BluetoothAddressAsString.CompareTo(b.BluetoothAddressAsString);
                 }
 
                 // RSSI == 0 means we don't know it. Always make that the end.
@@ -417,7 +417,8 @@ namespace BluetoothLEExplorer.Models
 
                 int newValue = (int)Math.Round(RssiValue.Average(), 0);
 
-                if (rssi != newValue)
+                if (rssi < newValue - 2 ||
+                    rssi > newValue + 2)
                 {
                     rssi = newValue;
                     OnPropertyChanged(new PropertyChangedEventArgs("RSSI"));

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Package.appxmanifest
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" IgnorableNamespaces="uap mp uap3">
-  <Identity Name="Microsoft.BluetoothLEExplorer" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="1.16.2.0" />
+  <Identity Name="Microsoft.BluetoothLEExplorer" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="1.16.3.0" />
   <mp:PhoneIdentity PhoneProductId="8fce680c-fda2-4d28-8e68-9bb7d53f192f" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Bluetooth LE Explorer</DisplayName>


### PR DESCRIPTION
Reduce the speed where devices shift around on the discovery page by slowing down rssi updates and giving a standard way of ordering devices if rssi is the same.