### PR TITLE
Adding BASS UUIDs to Gatt Service Enums

### DIFF
--- a/BluetoothLEExplorer/BluetoothLEExplorer/Services/GattUuidsService/GattUuidsService.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Services/GattUuidsService/GattUuidsService.cs
@@ -147,6 +147,7 @@ namespace BluetoothLEExplorer.Services.GattUuidHelpers
         TelephoneBearerService = 0x184B,
         GenericTelephoneBearerService = 0x184C,
         MicrophoneControl = 0x184D,
+        BroadcastAudioScan = 0x184F,
     }
 
     /// <summary>
@@ -409,6 +410,8 @@ namespace BluetoothLEExplorer.Services.GattUuidHelpers
         IncomingCall = 0x2BC1,
         CallFriendlyName = 0x2BC2,
         Mute = 0x2BC3,
+        BroadcastAudioScanControlPoint = 0x2BC4,
+        BroadcastReceiveState = 0x2BC5,
         SimpleKeyState = 0xFFE1,
     }
 

--- a/BluetoothLEExplorer/BluetoothLEExplorer/Services/GattUuidsService/GattUuidsService.cs
+++ b/BluetoothLEExplorer/BluetoothLEExplorer/Services/GattUuidsService/GattUuidsService.cs
@@ -410,8 +410,8 @@ namespace BluetoothLEExplorer.Services.GattUuidHelpers
         IncomingCall = 0x2BC1,
         CallFriendlyName = 0x2BC2,
         Mute = 0x2BC3,
-        BroadcastAudioScanControlPoint = 0x2BC4,
-        BroadcastReceiveState = 0x2BC5,
+        BroadcastAudioScanControlPoint = 0x2BC7,
+        BroadcastReceiveState = 0x2BC8,
         SimpleKeyState = 0xFFE1,
     }
 


### PR DESCRIPTION
As new services are added to the Bluetooth platform, the SIG assigns out additional UUIDs.

These UUIDs are useful for users to track what services and characteristics are exposed on their devices, and as a starting point o learn more about what their devices can do. 